### PR TITLE
Add `golangci-lint`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,10 +10,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,28 @@
+name: golangci-lint
+on:
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.41.1
+      - name: golangci-lint warnings
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.41.1
+          # Optional: golangci-lint command line arguments.
+          args: -c .golangci-warnings.yml

--- a/.golangci-warnings.yml
+++ b/.golangci-warnings.yml
@@ -1,0 +1,51 @@
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  disable-all: true
+  enable:
+    - staticcheck
+    - structcheck
+    - typecheck
+    - varcheck
+    - deadcode
+    - gosimple
+    - unused
+
+severity:
+  default-severity: warning
+
+issues:
+  # Disable default exclude rules listed in `golangci-lint run --help` (selectively re-enable some below)
+  exclude-use-default: false
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  exclude:
+    # ignore govet false positive fixed in https://github.com/golang/go/issues/45043
+    - "sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify"
+    # ignore golint false positive fixed in https://github.com/golang/lint/pull/487
+    - "exported method (.*).Unwrap` should have comment or be unexported"
+
+    # Enable some golangci-lint default exception rules:
+    # "EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok"
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    # "EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore"
+    - ineffective break statement. Did you mean to break out of the outer loop
+
+  exclude-rules:
+    # be more lenient with test code
+    - path: _test\.go
+      linters:
+        - staticcheck
+        - structcheck
+        - typecheck
+        - varcheck
+        - deadcode
+        - gosimple
+        - unused

--- a/.golangci-warnings.yml
+++ b/.golangci-warnings.yml
@@ -37,15 +37,3 @@ issues:
     - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
     # "EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore"
     - ineffective break statement. Did you mean to break out of the outer loop
-
-  exclude-rules:
-    # be more lenient with test code
-    - path: _test\.go
-      linters:
-        - staticcheck
-        - structcheck
-        - typecheck
-        - varcheck
-        - deadcode
-        - gosimple
-        - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  tests: false
+  tests: true
   
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+run:
+  timeout: 5m
+  tests: false
+  
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - golint
+    - govet
+    - ineffassign
+    - misspell
+
+severity:
+  default-severity: error
+
+issues:
+  # Disable default exclude rules listed in `golangci-lint run --help` (selectively re-enable some below)
+  exclude-use-default: false
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
+
+  exclude:
+    # ignore govet false positive fixed in https://github.com/golang/go/issues/45043
+    - "sigchanyzer: misuse of unbuffered os.Signal channel as argument to signal.Notify"
+    # ignore golint false positive fixed in https://github.com/golang/lint/pull/487
+    - "exported method (.*).Unwrap` should have comment or be unexported"
+
+    # Enable some golangci-lint default exception rules:
+    # "EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok"
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
+    # "EXC0005 staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore"
+    - ineffective break statement. Did you mean to break out of the outer loop


### PR DESCRIPTION
Add the `golangci-lint` linter, with config mirroring go-algorand's usage.