### PR TITLE
Add Makefile and simplify build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: "Build and Test"
+name: build
 
 on:
   pull_request:
@@ -17,12 +17,9 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version-file: 'go.mod'
-      
-    - name: Check Go Version
-      run: go version
 
     - name: Build
-      run: go build -v ./...
+      run: make build
 
     - name: Test
-      run: go test ./...
+      run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+
+build:
+	go build -v ./...
+
+test:
+	go test ./...
+
+fmt:
+	go fmt ./...
+
+lint:
+	golangci-lint run && golangci-lint run -c .golangci-warnings.yml
+
+.PHONY: build test fmt lint


### PR DESCRIPTION
Add a Makefile to ensure commonly used commands are consistent.

This Makefile is now used in our CI build file as much as possible.