### PR TITLE
Add codecov reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: auto
+        informational: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       run: make build
 
     - name: Test
-      run: go test ./... -race -covermode=atomic -coverprofile=coverage.out
+      run: make test-coverage output=coverage.out
     
     - name: Upload code coverage
       uses: codecov/codecov-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
+        files: coverage.out

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,9 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test ./...
+      run: go test ./... -race -covermode=atomic -coverprofile=coverage.out
+    
+    - name: Upload code coverage
+      uses: codecov/codecov-action@v3
+      with:
+        fail_ci_if_error: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ build:
 	go build -v ./...
 
 test:
-	go test ./...
+	go test ./... -race
+
+test-coverage:
+	$(if $(output),,$(error "output" variable not set))
+	go test ./... -race -covermode=atomic -coverprofile=$(output)
 
 fmt:
 	go fmt ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # avm-abi
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/algorand/avm-abi.svg)](https://pkg.go.dev/github.com/algorand/avm-abi)
+[![codecov](https://codecov.io/gh/algorand/avm-abi/branch/main/graph/badge.svg?token=SCDOA6NAIZ)](https://codecov.io/gh/algorand/avm-abi)
+
 An implementation of the Algorand [ARC-4](https://arc.algorand.foundation/ARCs/arc-0004) ABI type system.

--- a/abi/encode_test.go
+++ b/abi/encode_test.go
@@ -52,6 +52,7 @@ const (
 */
 
 func TestEncodeValid(t *testing.T) {
+	t.Parallel()
 	// encoding test for uint type, iterating through all uint sizes
 	// randomly pick 1000 valid uint values and check if encoded value match with expected
 	for intSize := uintBegin; intSize <= uintEnd; intSize += uintStepLength {
@@ -323,6 +324,7 @@ func TestEncodeValid(t *testing.T) {
 }
 
 func TestDecodeValid(t *testing.T) {
+	t.Parallel()
 	// decoding test for uint, iterating through all valid uint bitSize
 	// randomly take 1000 tests on each valid bitSize
 	// generate bytes from random uint values and decode bytes with additional type information
@@ -628,11 +630,13 @@ func TestDecodeValid(t *testing.T) {
 }
 
 func TestDecodeInvalid(t *testing.T) {
+	t.Parallel()
 	// decoding test for *corrupted* static bool array
 	// expected 9 elements for static bool array
 	// encoded bytes have only 8 bool values
 	// should throw error
 	t.Run("corrupted static bool array decode", func(t *testing.T) {
+		t.Parallel()
 		inputBase := []byte{0b11111111}
 		arrayType := makeStaticArrayType(boolType, 9)
 		_, err := arrayType.Decode(inputBase)
@@ -644,6 +648,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// encoded bytes have 1 byte more (0b00000000)
 	// should throw error
 	t.Run("corrupted static bool array decode", func(t *testing.T) {
+		t.Parallel()
 		inputBase := []byte{0b01001011, 0b00000000}
 		arrayType := makeStaticArrayType(boolType, 8)
 		_, err := arrayType.Decode(inputBase)
@@ -655,6 +660,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// encoded bytes provide only 7 uint64 encoding
 	// should throw error
 	t.Run("static uint array decode", func(t *testing.T) {
+		t.Parallel()
 		inputBase := []byte{
 			0, 0, 0, 0, 0, 0, 0, 0,
 			0, 0, 0, 0, 0, 0, 0, 1,
@@ -675,6 +681,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// encoded bytes provide 8 uint64 encoding (one more uint64: 7)
 	// should throw error
 	t.Run("static uint array decode", func(t *testing.T) {
+		t.Parallel()
 		inputBase := []byte{
 			0, 0, 0, 0, 0, 0, 0, 0,
 			0, 0, 0, 0, 0, 0, 0, 1,
@@ -696,6 +703,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// encoded bytes provide only 8 bool elements
 	// should throw error
 	t.Run("corrupted dynamic bool array decode", func(t *testing.T) {
+		t.Parallel()
 		inputBase := []byte{
 			0x00, 0x0A, 0b10101010,
 		}
@@ -709,6 +717,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// encoded bytes provide 1 byte more (0b00000000)
 	// should throw error
 	t.Run("corrupted dynamic bool array decode", func(t *testing.T) {
+		t.Parallel()
 		inputBase := []byte{
 			0x00, 0x07, 0b10101010, 0b00000000,
 		}
@@ -734,6 +743,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// the length exceeds the segment it allocated: 0x0A, 0x00, 0x03, byte('A'), byte('B'), byte('C')
 	// should throw error
 	t.Run("corrupted dynamic tuple decoding", func(t *testing.T) {
+		t.Parallel()
 		inputEncode := []byte{
 			0x00, 0x04, 0b10100000, 0x00, 0x0A,
 			0x00, 0x03, byte('A'), byte('B'), byte('C'),
@@ -759,6 +769,7 @@ func TestDecodeInvalid(t *testing.T) {
 		                <- corrupted byte, 1 byte missing
 	*/
 	t.Run("corrupted static bool array tuple decoding", func(t *testing.T) {
+		t.Parallel()
 		expectedType, err := TypeOf("(bool[2],bool[2])")
 		require.NoError(t, err, "make tuple type failure")
 		encodedInput0 := []byte{
@@ -787,6 +798,7 @@ func TestDecodeInvalid(t *testing.T) {
 	   0b11000000      (second static bool array)
 	*/
 	t.Run("corrupted static/dynamic bool array tuple decoding", func(t *testing.T) {
+		t.Parallel()
 		encodedInput := []byte{
 			0b11000000,
 			0x03,
@@ -813,6 +825,7 @@ func TestDecodeInvalid(t *testing.T) {
 	*/
 	// should return error
 	t.Run("corrupted empty dynamic array tuple decoding", func(t *testing.T) {
+		t.Parallel()
 		encodedInput := []byte{
 			0x00, 0x04, 0x00, 0x07,
 			0x00, 0x00, 0x00, 0x00,
@@ -828,6 +841,7 @@ func TestDecodeInvalid(t *testing.T) {
 	// corrupted input: 0xFF, should be empty byte
 	// should return error
 	t.Run("corrupted empty tuple decoding", func(t *testing.T) {
+		t.Parallel()
 		encodedInput := []byte{0xFF}
 		tupleT, err := TypeOf("()")
 		require.NoError(t, err, "make tuple type failure")
@@ -1021,6 +1035,7 @@ func addTupleRandomValues(t *testing.T, slotRange BaseType, pool *map[BaseType][
 }
 
 func TestRandomABIEncodeDecodeRoundTrip(t *testing.T) {
+	t.Parallel()
 	testValuePool := make(map[BaseType][]testUnit)
 	addPrimitiveRandomValues(t, &testValuePool)
 	addArrayRandomValues(t, &testValuePool)
@@ -1030,6 +1045,7 @@ func TestRandomABIEncodeDecodeRoundTrip(t *testing.T) {
 }
 
 func TestParseMethodSignature(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		signature  string
 		name       string
@@ -1080,6 +1096,7 @@ func TestParseMethodSignature(t *testing.T) {
 }
 
 func TestVerifyMethodSignature(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		method string
 		pass   bool
@@ -1130,6 +1147,7 @@ func TestVerifyMethodSignature(t *testing.T) {
 }
 
 func TestInferToSlice(t *testing.T) {
+	t.Parallel()
 	var emptySlice []int
 	tests := []struct {
 		toBeInferred interface{}

--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestMakeTypeValid(t *testing.T) {
+	t.Parallel()
 	// uint
 	for i := 8; i <= 512; i += 8 {
 		uintType, err := makeUintType(i)
@@ -127,6 +128,7 @@ func TestMakeTypeValid(t *testing.T) {
 }
 
 func TestMakeTypeInvalid(t *testing.T) {
+	t.Parallel()
 	// uint
 	for i := 0; i <= 1000; i++ {
 		randInput := rand.Uint32() % (1 << 16)
@@ -153,6 +155,7 @@ func TestMakeTypeInvalid(t *testing.T) {
 }
 
 func TestTypeFromStringValid(t *testing.T) {
+	t.Parallel()
 	// uint
 	for i := 8; i <= 512; i += 8 {
 		expected, err := makeUintType(i)
@@ -361,6 +364,7 @@ func TestTypeFromStringValid(t *testing.T) {
 }
 
 func TestTypeFromStringInvalid(t *testing.T) {
+	t.Parallel()
 	for i := 0; i <= 1000; i++ {
 		randSize := rand.Uint64()
 		for randSize%8 == 0 && randSize <= 512 && randSize >= 8 {
@@ -449,6 +453,7 @@ func generateTupleType(baseTypes []Type, tupleTypes []Type) Type {
 }
 
 func TestTypeMISC(t *testing.T) {
+	t.Parallel()
 	rand.Seed(time.Now().Unix())
 
 	var testpool = []Type{


### PR DESCRIPTION
Add code coverage reporting with Codecov.

The configuration mirrors go-algorand. In other words, coverage is reported for informational purposes only.

We may want to consider enforcing some minimum amount of coverage required for PRs, but I've not attempted that currently.