### PR TITLE
Rename `BaseType` to `TypeKind`

### DIFF
--- a/abi/encode.go
+++ b/abi/encode.go
@@ -12,7 +12,7 @@ import (
 func (t Type) typeCastToTuple(tupLen ...int) (Type, error) {
 	var childT []Type
 
-	switch t.abiTypeID {
+	switch t.kind {
 	case String:
 		if len(tupLen) != 1 {
 			return Type{}, fmt.Errorf("string type conversion to tuple need 1 length argument")
@@ -52,7 +52,7 @@ func (t Type) typeCastToTuple(tupLen ...int) (Type, error) {
 
 // Encode is an ABI type method to encode go values into bytes following ABI encoding rules
 func (t Type) Encode(value interface{}) ([]byte, error) {
-	switch t.abiTypeID {
+	switch t.kind {
 	case Uint, Ufixed:
 		return encodeInt(value, t.bitSize)
 	case Bool:
@@ -211,7 +211,7 @@ func encodeTuple(value interface{}, childT []Type) ([]byte, error) {
 			}
 			tails[i] = tailEncoding
 			isDynamicIndex[i] = true
-		} else if childT[i].abiTypeID == Bool {
+		} else if childT[i].kind == Bool {
 			// search previous bool
 			before := findBoolLR(childT, i, -1)
 			// search after bool
@@ -317,7 +317,7 @@ func decodeUint(encoded []byte, bitSize uint16) (interface{}, error) {
 
 // Decode is an ABI type method to decode bytes to go values from ABI encoding rules
 func (t Type) Decode(encoded []byte) (interface{}, error) {
-	switch t.abiTypeID {
+	switch t.kind {
 	case Uint, Ufixed:
 		return decodeUint(encoded, t.bitSize)
 	case Bool:
@@ -389,7 +389,7 @@ func decodeTuple(encoded []byte, childT []Type) ([]interface{}, error) {
 			dynamicSegments = append(dynamicSegments, int(dynamicIndex))
 			valuePartition = append(valuePartition, nil)
 			iterIndex += lengthEncodeByteSize
-		} else if childT[i].abiTypeID == Bool {
+		} else if childT[i].kind == Bool {
 			// search previous bool
 			before := findBoolLR(childT, i, -1)
 			// search after bool

--- a/abi/encode_test.go
+++ b/abi/encode_test.go
@@ -885,7 +885,7 @@ func categorySelfRoundTripTest(t *testing.T, category []testUnit) {
 	}
 }
 
-func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
+func addPrimitiveRandomValues(t *testing.T, pool *map[TypeKind][]testUnit) {
 	(*pool)[Uint] = make([]testUnit, uintTestCaseCount*uintEnd/uintStepLength)
 	(*pool)[Ufixed] = make([]testUnit, ufixedPrecision*uintEnd/uintStepLength)
 
@@ -964,7 +964,7 @@ func addPrimitiveRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
 }
 
 func takeSomeFromCategoryAndGenerateArray(
-	t *testing.T, abiT BaseType, srtIndex int, takeNum uint16, pool *map[BaseType][]testUnit) {
+	t *testing.T, abiT TypeKind, srtIndex int, takeNum uint16, pool *map[TypeKind][]testUnit) {
 
 	tempArray := make([]interface{}, takeNum)
 	for i := 0; i < int(takeNum); i++ {
@@ -986,7 +986,7 @@ func takeSomeFromCategoryAndGenerateArray(
 	})
 }
 
-func addArrayRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
+func addArrayRandomValues(t *testing.T, pool *map[TypeKind][]testUnit) {
 	for intIndex := 0; intIndex < len((*pool)[Uint]); intIndex += uintTestCaseCount {
 		takeSomeFromCategoryAndGenerateArray(t, Uint, intIndex, takeNum, pool)
 	}
@@ -999,16 +999,16 @@ func addArrayRandomValues(t *testing.T, pool *map[BaseType][]testUnit) {
 	categorySelfRoundTripTest(t, (*pool)[ArrayDynamic])
 }
 
-func addTupleRandomValues(t *testing.T, slotRange BaseType, pool *map[BaseType][]testUnit) {
+func addTupleRandomValues(t *testing.T, slotRange TypeKind, pool *map[TypeKind][]testUnit) {
 	for i := 0; i < tupleTestCaseCount; i++ {
 		tupleLenBig, err := rand.Int(rand.Reader, big.NewInt(tupleMaxLength))
 		require.NoError(t, err, "generate random tuple length should not return error")
 		tupleLen := tupleLenBig.Int64() + 1
 		testUnits := make([]testUnit, tupleLen)
 		for index := 0; index < int(tupleLen); index++ {
-			tupleTypeIndexBig, err := rand.Int(rand.Reader, big.NewInt(int64(slotRange)+1))
+			tupleTypeIndexBig, err := rand.Int(rand.Reader, big.NewInt(int64(slotRange)))
 			require.NoError(t, err, "generate random tuple element type index should not return error")
-			tupleTypeIndex := BaseType(tupleTypeIndexBig.Int64())
+			tupleTypeIndex := TypeKind(tupleTypeIndexBig.Int64() + 1)
 			tupleElemChoiceRange := len((*pool)[tupleTypeIndex])
 
 			tupleElemRangeIndexBig, err := rand.Int(rand.Reader, big.NewInt(int64(tupleElemChoiceRange)))
@@ -1036,7 +1036,7 @@ func addTupleRandomValues(t *testing.T, slotRange BaseType, pool *map[BaseType][
 
 func TestRandomABIEncodeDecodeRoundTrip(t *testing.T) {
 	t.Parallel()
-	testValuePool := make(map[BaseType][]testUnit)
+	testValuePool := make(map[TypeKind][]testUnit)
 	addPrimitiveRandomValues(t, &testValuePool)
 	addArrayRandomValues(t, &testValuePool)
 	addTupleRandomValues(t, String, &testValuePool)


### PR DESCRIPTION
This PR renames the `BaseType` enum to `TypeKind` to hopefully make its purpose clearer. This rename was inspired by go's `reflect.Kind` enum.

Additionally, a new zero value for the `TypeKind` enum has been introduced, `InvalidType`. Previously, `Uint` was the zero value, which meant the zero value of `Type` appeared to be a `Uint`. This behavior seemed undesirable.