### PR TITLE
Replace deprecated golint with revive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ go.work
 
 # Mac
 .DS_Store
+
+# IDEs
+.idea/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters:
   enable:
     - errcheck
     - gofmt
-    - golint
+    - revive
     - govet
     - ineffassign
     - misspell

--- a/abi/encode.go
+++ b/abi/encode.go
@@ -279,7 +279,7 @@ func encodeTuple(value interface{}, childT []Type) ([]byte, error) {
 // compressBools takes a slice of interface{} (which can be casted to bools) length <= 8
 // and compress the bool values into a uint8 integer
 func compressBools(boolSlice []interface{}) (uint8, error) {
-	var res uint8 = 0
+	var res uint8
 	if len(boolSlice) > 8 {
 		return 0, fmt.Errorf("compressBools: cannot have slice length > 8")
 	}

--- a/abi/encode_test.go
+++ b/abi/encode_test.go
@@ -1193,7 +1193,7 @@ func TestInferToSlice(t *testing.T) {
 		"inferToSlice should return type inference error when passed in nil with unexpected Kind")
 
 	// one moar testcase for wrong typed nil is bad, should not pass the test
-	var nilPt *uint64 = nil
+	var nilPt *uint64
 	_, err = inferToSlice(nilPt)
 	require.EqualError(
 		t, err,


### PR DESCRIPTION
Addresses golint deprecation warning by replacing with revive like https://github.com/algorand/go-algorand/pull/4418/.

Output on `main`:
```
❯ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.41.0 golangci-lint run
level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."
```

Output after configuring _revive_:
```
❯ docker run --rm -v $(pwd):/app -w /app golangci/golangci-lint:v1.41.0 golangci-lint run
abi/encode_test.go:1196:22: var-declaration: should drop = nil from declaration of var nilPt; it is the zero value (revive)
	var nilPt *uint64 = nil
	                    ^
abi/encode.go:282:18: var-declaration: should drop = 0 from declaration of var res; it is the zero value (revive)
	var res uint8 = 0
```

For the PR's scope, I didn't closely investigate tooling configuration.  The intent is to avoid extending usage of deprecated tooling.