### PR TITLE
Add ABI test case for leading 0-sized array

### DIFF
--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -521,6 +521,7 @@ func TestTypeFromStringInvalid(t *testing.T) {
 		"[][][]",
 		"stuff[]",
 		// static array
+		"byte[01]",
 		"byte[10 ]",
 		"uint64[0x21]",
 		// tuple


### PR DESCRIPTION
Adds a test case motivated by discussion in https://github.com/algorand/js-algorand-sdk/pull/698#discussion_r1035024671. 